### PR TITLE
chore: upgrade EVM target to Cancun + OZ 5.6.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ QFC smart contract example library built with Hardhat and Solidity. Provides pro
 
 ## Tech Stack
 
-- **Solidity** ^0.8.20 - Smart contract language
+- **Solidity** ^0.8.24 (Cancun EVM) - Smart contract language
 - **Hardhat** - Development framework
 - **OpenZeppelin** - Security-audited contract libraries
 - **TypeScript** - Scripts and tests

--- a/contracts/staking/StakingPool.sol
+++ b/contracts/staking/StakingPool.sol
@@ -111,7 +111,7 @@ contract StakingPool is ReentrancyGuard, Ownable {
      * @dev Withdraw staked tokens
      * @param amount Amount to withdraw
      */
-    function withdraw(uint256 amount) external nonReentrant updateReward(msg.sender) {
+    function withdraw(uint256 amount) public nonReentrant updateReward(msg.sender) {
         require(amount > 0, "Cannot withdraw 0");
         require(stakes[msg.sender].amount >= amount, "Insufficient stake");
         require(
@@ -130,7 +130,7 @@ contract StakingPool is ReentrancyGuard, Ownable {
     /**
      * @dev Claim rewards
      */
-    function claimRewards() external nonReentrant updateReward(msg.sender) {
+    function claimRewards() public nonReentrant updateReward(msg.sender) {
         uint256 reward = stakes[msg.sender].rewards;
         if (reward > 0) {
             stakes[msg.sender].rewards = 0;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,6 +12,7 @@ const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.24",
     settings: {
+      evmVersion: "cancun",
       optimizer: {
         enabled: true,
         runs: 200,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@nomicfoundation/hardhat-verify": "^2.0.0",
-        "@openzeppelin/contracts": "^5.1.0",
+        "@openzeppelin/contracts": "^5.6.1",
         "@typechain/ethers-v6": "^0.5.0",
         "@typechain/hardhat": "^9.0.0",
         "@types/chai": "^4.3.0",
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.1.0.tgz",
-      "integrity": "sha512-p1ULhl7BXzjjbha5aqst+QMLY+4/LCWADXOCsmLHRM77AqiPjnd9vvUN9sosUfhL9JGKpZ0TjEGxgvnizmWGSA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.6.1.tgz",
+      "integrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
-    "@openzeppelin/contracts": "^5.1.0",
+    "@openzeppelin/contracts": "^5.6.1",
     "@typechain/ethers-v6": "^0.5.0",
     "@typechain/hardhat": "^9.0.0",
     "@types/chai": "^4.3.0",


### PR DESCRIPTION
## Summary
- Set `evmVersion: "cancun"` in `hardhat.config.ts`
- Upgrade `@openzeppelin/contracts` from 5.1.0 → 5.6.1
- Fix `StakingPool.sol`: `withdraw`/`claimRewards` `external` → `public` (forward-reference compilation error)

QFC node already runs Cancun EVM spec (revm defaults to LATEST). This aligns the compiler target so contracts can use PUSH0, MCOPY, TSTORE/TLOAD for better gas efficiency.

## Related PRs
- qfc-network/qfc-core — explicit `SpecId::CANCUN`
- qfc-network/qfc-explorer-api — verification default → cancun

## Test plan
- [x] 93 Solidity files compile with `evm target: cancun`
- [x] 30 inference tests pass
- [ ] Deploy to local hardhat node

🤖 Generated with [Claude Code](https://claude.com/claude-code)