### PR TITLE
feat: ResultVerifier — inference result challenge-response verification

### DIFF
--- a/contracts/inference/MinerRegistry.sol
+++ b/contracts/inference/MinerRegistry.sol
@@ -32,18 +32,29 @@ contract MinerRegistry is Ownable {
     /// @notice TaskRegistry address, authorized to update miner stats
     address public taskRegistry;
 
+    /// @notice ResultVerifier address, authorized to slash miners
+    address public resultVerifier;
+
     event MinerRegistered(address indexed miner, uint8 tier, string endpoint);
     event MinerStatusUpdated(address indexed miner, Status status);
     event MinerStatsUpdated(address indexed miner, uint256 completed, uint256 failed, uint256 reputation);
+    event MinerSlashed(address indexed miner, uint256 penaltyBps);
     event TaskRegistrySet(address indexed taskRegistry);
+    event ResultVerifierSet(address indexed resultVerifier);
 
     error AlreadyRegistered();
     error NotRegistered();
     error InvalidTier(uint8 tier);
     error OnlyTaskRegistry();
+    error OnlyResultVerifier();
 
     modifier onlyTaskRegistry() {
         if (msg.sender != taskRegistry) revert OnlyTaskRegistry();
+        _;
+    }
+
+    modifier onlyResultVerifier() {
+        if (msg.sender != resultVerifier) revert OnlyResultVerifier();
         _;
     }
 
@@ -57,6 +68,16 @@ contract MinerRegistry is Ownable {
         require(_taskRegistry != address(0), "Zero address");
         taskRegistry = _taskRegistry;
         emit TaskRegistrySet(_taskRegistry);
+    }
+
+    /**
+     * @notice Set the ResultVerifier address. Only owner.
+     * @param _resultVerifier Address of the ResultVerifier contract.
+     */
+    function setResultVerifier(address _resultVerifier) external onlyOwner {
+        require(_resultVerifier != address(0), "Zero address");
+        resultVerifier = _resultVerifier;
+        emit ResultVerifierSet(_resultVerifier);
     }
 
     /**
@@ -111,6 +132,30 @@ contract MinerRegistry is Ownable {
         Miner storage m = _miners[miner];
         m.failed++;
         _updateReputation(m);
+        emit MinerStatsUpdated(miner, m.completed, m.failed, m.reputation);
+    }
+
+    /**
+     * @notice Slash a miner's reputation. Called by ResultVerifier on upheld challenges.
+     * @param miner The miner address.
+     * @param penaltyBps Reputation penalty in basis points (e.g. 1000 = 10%).
+     */
+    function slash(address miner, uint256 penaltyBps) external onlyResultVerifier {
+        Miner storage m = _miners[miner];
+        if (!m.registered) revert NotRegistered();
+
+        // Record failure
+        m.failed++;
+
+        // Apply reputation penalty
+        uint256 penalty = (m.reputation * penaltyBps) / 10000;
+        if (penalty > m.reputation) {
+            m.reputation = 0;
+        } else {
+            m.reputation -= penalty;
+        }
+
+        emit MinerSlashed(miner, penaltyBps);
         emit MinerStatsUpdated(miner, m.completed, m.failed, m.reputation);
     }
 

--- a/contracts/inference/ResultVerifier.sol
+++ b/contracts/inference/ResultVerifier.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./TaskRegistry.sol";
 import "./MinerRegistry.sol";
 
@@ -10,16 +11,25 @@ import "./MinerRegistry.sol";
  * @notice Challenge-response verification for inference results.
  *         Anyone can challenge a completed task within the challenge window.
  *         Validators vote on challenges; if upheld, the miner is slashed.
+ *
+ * Flow:
+ *   1. Miner submits result + hash proof via TaskRegistry
+ *   2. 10-min challenge window — any miner can dispute
+ *   3. Validators vote on the challenge
+ *   4. Owner resolves: upheld → miner slashed (10% reputation),
+ *      challenger refunded; rejected → challenger loses stake
  */
-contract ResultVerifier is Ownable {
+contract ResultVerifier is Ownable, ReentrancyGuard {
     enum ChallengeStatus { Open, Upheld, Rejected, Expired }
 
     struct Challenge {
-        uint256 taskId;
+        bytes32 taskId;
         address challenger;
+        bytes32 challengerResultHash;
         string reason;
         ChallengeStatus status;
         uint256 createdAt;
+        uint256 stake;
         uint256 votesFor;     // votes to uphold (miner was wrong)
         uint256 votesAgainst; // votes to reject (miner was right)
     }
@@ -27,52 +37,71 @@ contract ResultVerifier is Ownable {
     TaskRegistry public immutable taskRegistry;
     MinerRegistry public immutable minerRegistry;
 
-    uint256 public challengeWindow = 600; // 10 minutes after completion
-    uint256 public slashAmount;
+    /// @notice Challenge window in seconds after task completion (default 10 min)
+    uint256 public challengeWindow = 600;
+
+    /// @notice Reputation slash penalty in basis points (default 1000 = 10%)
+    uint256 public slashPenaltyBps = 1000;
+
+    /// @notice Minimum stake required to file a challenge
     uint256 public minChallengeStake;
+
+    /// @notice Protocol's share of forfeited challenger stakes (basis points, default 5000 = 50%)
+    uint256 public protocolShareBps = 5000;
+
+    /// @notice Accumulated protocol revenue from forfeited stakes
+    uint256 public protocolFees;
+
     uint256 public nextChallengeId;
 
     mapping(uint256 => Challenge) private _challenges;
     /// @dev taskId => challengeId (one challenge per task)
-    mapping(uint256 => uint256) public taskChallenge;
+    mapping(bytes32 => uint256) public taskChallenge;
     /// @dev challengeId => validator => voted
     mapping(uint256 => mapping(address => bool)) public hasVoted;
     /// @dev validator address => authorized
     mapping(address => bool) public validators;
 
-    event ChallengeCreated(uint256 indexed challengeId, uint256 indexed taskId, address indexed challenger);
+    event ChallengeCreated(uint256 indexed challengeId, bytes32 indexed taskId, address indexed challenger);
     event VoteCast(uint256 indexed challengeId, address indexed validator, bool uphold);
     event ChallengeResolved(uint256 indexed challengeId, ChallengeStatus status);
+    event ChallengeExpired(uint256 indexed challengeId);
     event ValidatorAdded(address indexed validator);
     event ValidatorRemoved(address indexed validator);
     event ChallengeWindowUpdated(uint256 newWindow);
-    event SlashAmountUpdated(uint256 newAmount);
+    event SlashPenaltyUpdated(uint256 newPenaltyBps);
+    event ProtocolFeesClaimed(address indexed to, uint256 amount);
 
-    error TaskNotCompleted(uint256 taskId);
-    error ChallengeWindowClosed(uint256 taskId);
-    error AlreadyChallenged(uint256 taskId);
+    error TaskNotCompleted(bytes32 taskId);
+    error ChallengeWindowClosed(bytes32 taskId);
+    error AlreadyChallenged(bytes32 taskId);
     error ChallengeNotFound(uint256 challengeId);
     error ChallengeNotOpen(uint256 challengeId);
     error NotValidator(address addr);
     error AlreadyVoted(uint256 challengeId, address validator);
     error InsufficientStake(uint256 required, uint256 provided);
+    error NoProtocolFees();
+    error TransferFailed();
 
     constructor(
         address _taskRegistry,
         address _minerRegistry,
-        uint256 _slashAmount,
         uint256 _minChallengeStake
     ) Ownable(msg.sender) {
         taskRegistry = TaskRegistry(_taskRegistry);
         minerRegistry = MinerRegistry(_minerRegistry);
-        slashAmount = _slashAmount;
         minChallengeStake = _minChallengeStake;
     }
 
     /// @notice Challenge a completed task's result
     /// @param taskId The completed task to challenge
+    /// @param challengerResultHash Hash of the challenger's re-computed result
     /// @param reason Description of why the result is wrong
-    function challenge(uint256 taskId, string calldata reason) external payable returns (uint256 challengeId) {
+    function challengeResult(
+        bytes32 taskId,
+        bytes32 challengerResultHash,
+        string calldata reason
+    ) external payable returns (uint256 challengeId) {
         if (msg.value < minChallengeStake) revert InsufficientStake(minChallengeStake, msg.value);
 
         TaskRegistry.Task memory task = taskRegistry.getTask(taskId);
@@ -84,9 +113,11 @@ contract ResultVerifier is Ownable {
         _challenges[challengeId] = Challenge({
             taskId: taskId,
             challenger: msg.sender,
+            challengerResultHash: challengerResultHash,
             reason: reason,
             status: ChallengeStatus.Open,
             createdAt: block.timestamp,
+            stake: msg.value,
             votesFor: 0,
             votesAgainst: 0
         });
@@ -115,9 +146,9 @@ contract ResultVerifier is Ownable {
         emit VoteCast(challengeId, msg.sender, uphold);
     }
 
-    /// @notice Resolve a challenge after voting (owner/automated)
+    /// @notice Resolve a challenge after voting
     /// @param challengeId The challenge to resolve
-    function resolve(uint256 challengeId) external onlyOwner {
+    function resolveChallenge(uint256 challengeId) external onlyOwner nonReentrant {
         Challenge storage c = _challenges[challengeId];
         if (c.createdAt == 0) revert ChallengeNotFound(challengeId);
         if (c.status != ChallengeStatus.Open) revert ChallengeNotOpen(challengeId);
@@ -127,17 +158,43 @@ contract ResultVerifier is Ownable {
         if (c.votesFor > c.votesAgainst) {
             // Challenge upheld — slash miner, refund challenger
             c.status = ChallengeStatus.Upheld;
-            minerRegistry.slash(task.miner, slashAmount);
+
+            // Slash miner reputation (10% default)
+            minerRegistry.slash(task.miner, slashPenaltyBps);
 
             // Refund challenger stake
-            (bool ok, ) = c.challenger.call{value: minChallengeStake}("");
-            if (!ok) { /* challenger can't receive, stake stays in contract */ }
+            (bool ok, ) = c.challenger.call{value: c.stake}("");
+            if (!ok) revert TransferFailed();
         } else {
             // Challenge rejected — challenger loses stake
             c.status = ChallengeStatus.Rejected;
+
+            // Split forfeited stake: 50% protocol, 50% to contract (can be extended for miner reward)
+            uint256 protocolAmount = (c.stake * protocolShareBps) / 10000;
+            protocolFees += protocolAmount;
+            // Remaining stake stays in contract
         }
 
         emit ChallengeResolved(challengeId, c.status);
+    }
+
+    /// @notice Expire an unchallenged or unresolved challenge after the window
+    /// @param challengeId The challenge to expire
+    function expireChallenge(uint256 challengeId) external {
+        Challenge storage c = _challenges[challengeId];
+        if (c.createdAt == 0) revert ChallengeNotFound(challengeId);
+        if (c.status != ChallengeStatus.Open) revert ChallengeNotOpen(challengeId);
+
+        // Can only expire after challenge window has passed since creation
+        require(block.timestamp > c.createdAt + challengeWindow, "Challenge window not expired");
+
+        c.status = ChallengeStatus.Expired;
+
+        // Refund challenger stake on expiry (no votes = inconclusive)
+        (bool ok, ) = c.challenger.call{value: c.stake}("");
+        if (!ok) revert TransferFailed();
+
+        emit ChallengeExpired(challengeId);
     }
 
     /// @notice Get challenge details
@@ -163,8 +220,18 @@ contract ResultVerifier is Ownable {
         emit ChallengeWindowUpdated(newWindow);
     }
 
-    function setSlashAmount(uint256 newAmount) external onlyOwner {
-        slashAmount = newAmount;
-        emit SlashAmountUpdated(newAmount);
+    function setSlashPenalty(uint256 newPenaltyBps) external onlyOwner {
+        require(newPenaltyBps <= 10000, "Exceeds 100%");
+        slashPenaltyBps = newPenaltyBps;
+        emit SlashPenaltyUpdated(newPenaltyBps);
+    }
+
+    function claimProtocolFees() external onlyOwner nonReentrant {
+        if (protocolFees == 0) revert NoProtocolFees();
+        uint256 amount = protocolFees;
+        protocolFees = 0;
+        (bool ok, ) = msg.sender.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+        emit ProtocolFeesClaimed(msg.sender, amount);
     }
 }

--- a/contracts/inference/TaskRegistry.sol
+++ b/contracts/inference/TaskRegistry.sol
@@ -26,6 +26,7 @@ contract TaskRegistry is Ownable, ReentrancyGuard {
         uint256 maxFee;
         TaskStatus status;
         uint256 createdAt;
+        uint256 completedAt;
     }
 
     /// @notice Task ID => Task info
@@ -121,7 +122,8 @@ contract TaskRegistry is Ownable, ReentrancyGuard {
             miner: address(0),
             maxFee: maxFee,
             status: TaskStatus.Pending,
-            createdAt: block.timestamp
+            createdAt: block.timestamp,
+            completedAt: 0
         });
 
         // Add to open tasks
@@ -180,6 +182,7 @@ contract TaskRegistry is Ownable, ReentrancyGuard {
         task.status = TaskStatus.Completed;
         task.resultHash = resultHash;
         task.proof = proof;
+        task.completedAt = block.timestamp;
 
         // Release fee to miner
         feeEscrow.releaseFee(taskId, msg.sender);
@@ -210,6 +213,16 @@ contract TaskRegistry is Ownable, ReentrancyGuard {
         feeEscrow.refundFee(taskId);
 
         emit TaskCancelled(taskId);
+    }
+
+    /**
+     * @notice Get full task details.
+     * @param taskId The task ID.
+     * @return task The Task struct.
+     */
+    function getTask(bytes32 taskId) external view returns (Task memory) {
+        if (tasks[taskId].submitter == address(0)) revert TaskNotFound(taskId);
+        return tasks[taskId];
     }
 
     /**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,7 +10,7 @@ const PRIVATE_KEY = process.env.PRIVATE_KEY || "0x000000000000000000000000000000
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.27",
+    version: "0.8.28",
     settings: {
       evmVersion: "cancun",
       optimizer: {

--- a/test/Inference.test.ts
+++ b/test/Inference.test.ts
@@ -16,8 +16,11 @@ describe("Inference Marketplace", function () {
   const RESULT_HASH = ethers.id("test-result-data");
   const PROOF = ethers.id("test-proof");
 
+  const MIN_CHALLENGE_STAKE = ethers.parseEther("0.1");
+  const CHALLENGER_RESULT = ethers.id("challenger-result-data");
+
   async function deployFixture() {
-    const [owner, router, miner1, miner2, user1, user2] = await ethers.getSigners();
+    const [owner, router, miner1, miner2, user1, user2, validator1, validator2] = await ethers.getSigners();
 
     // Deploy contracts
     const ModelRegistry = await ethers.getContractFactory("ModelRegistry");
@@ -36,8 +39,16 @@ describe("Inference Marketplace", function () {
       await feeEscrow.getAddress()
     );
 
+    const ResultVerifier = await ethers.getContractFactory("ResultVerifier");
+    const resultVerifier = await ResultVerifier.deploy(
+      await taskRegistry.getAddress(),
+      await minerRegistry.getAddress(),
+      MIN_CHALLENGE_STAKE
+    );
+
     // Wire together
     await minerRegistry.setTaskRegistry(await taskRegistry.getAddress());
+    await minerRegistry.setResultVerifier(await resultVerifier.getAddress());
     await feeEscrow.setTaskRegistry(await taskRegistry.getAddress());
     await taskRegistry.setRouter(router.address);
 
@@ -46,7 +57,7 @@ describe("Inference Marketplace", function () {
     await modelRegistry.registerModel(LLAMA3_70B, "llama3-70b", 2, BASE_FEE_70B);
     await modelRegistry.registerModel(WHISPER, "whisper-large-v3", 1, BASE_FEE_WHISPER);
 
-    return { modelRegistry, minerRegistry, feeEscrow, taskRegistry, owner, router, miner1, miner2, user1, user2 };
+    return { modelRegistry, minerRegistry, feeEscrow, taskRegistry, resultVerifier, owner, router, miner1, miner2, user1, user2, validator1, validator2 };
   }
 
   // ─── ModelRegistry ─────────────────────────────────────────────
@@ -441,6 +452,297 @@ describe("Inference Marketplace", function () {
       await expect(
         feeEscrow.claimProtocolFees()
       ).to.be.revertedWithCustomError(feeEscrow, "NoProtocolFees");
+    });
+  });
+
+  // ─── ResultVerifier ──────────────────────────────────────────────
+
+  describe("ResultVerifier", function () {
+    async function completedTaskFixture() {
+      const fixture = await deployFixture();
+      const { taskRegistry, minerRegistry, resultVerifier, miner1, user1, router, owner, validator1, validator2 } = fixture;
+
+      await minerRegistry.connect(miner1).registerMiner(2, "https://miner1.example.com");
+
+      // Submit + assign + complete task
+      const tx = await taskRegistry
+        .connect(user1)
+        .submitTask(LLAMA3_8B, INPUT_HASH, BASE_FEE_8B, { value: BASE_FEE_8B });
+      const receipt = await tx.wait();
+      const event = receipt?.logs.find(
+        (log: any) => log.fragment?.name === "TaskSubmitted"
+      ) as any;
+      const taskId = event.args[0];
+
+      await taskRegistry.connect(router).assignTask(taskId, miner1.address);
+      await taskRegistry.connect(miner1).submitResult(taskId, RESULT_HASH, PROOF);
+
+      // Add validators
+      await resultVerifier.addValidator(validator1.address);
+      await resultVerifier.addValidator(validator2.address);
+
+      return { ...fixture, taskId };
+    }
+
+    it("Should create a challenge on a completed task", async function () {
+      const { resultVerifier, user2, taskId } = await loadFixture(completedTaskFixture);
+
+      await expect(
+        resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong output", { value: MIN_CHALLENGE_STAKE })
+      ).to.emit(resultVerifier, "ChallengeCreated")
+        .withArgs(1, taskId, user2.address);
+
+      const challenge = await resultVerifier.getChallenge(1);
+      expect(challenge.taskId).to.equal(taskId);
+      expect(challenge.challenger).to.equal(user2.address);
+      expect(challenge.challengerResultHash).to.equal(CHALLENGER_RESULT);
+      expect(challenge.status).to.equal(0); // Open
+      expect(challenge.stake).to.equal(MIN_CHALLENGE_STAKE);
+    });
+
+    it("Should reject challenge with insufficient stake", async function () {
+      const { resultVerifier, user2, taskId } = await loadFixture(completedTaskFixture);
+      const lowStake = ethers.parseEther("0.01");
+
+      await expect(
+        resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: lowStake })
+      ).to.be.revertedWithCustomError(resultVerifier, "InsufficientStake");
+    });
+
+    it("Should reject challenge on non-completed task", async function () {
+      const { taskRegistry, resultVerifier, user1, user2 } = await loadFixture(deployFixture);
+
+      // Submit but don't complete
+      const tx = await taskRegistry
+        .connect(user1)
+        .submitTask(LLAMA3_8B, INPUT_HASH, BASE_FEE_8B, { value: BASE_FEE_8B });
+      const receipt = await tx.wait();
+      const event = receipt?.logs.find(
+        (log: any) => log.fragment?.name === "TaskSubmitted"
+      ) as any;
+      const taskId = event.args[0];
+
+      await expect(
+        resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE })
+      ).to.be.revertedWithCustomError(resultVerifier, "TaskNotCompleted");
+    });
+
+    it("Should reject duplicate challenge", async function () {
+      const { resultVerifier, user1, user2, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user1).challengeResult(taskId, CHALLENGER_RESULT, "Wrong 1", { value: MIN_CHALLENGE_STAKE });
+
+      await expect(
+        resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong 2", { value: MIN_CHALLENGE_STAKE })
+      ).to.be.revertedWithCustomError(resultVerifier, "AlreadyChallenged");
+    });
+
+    it("Should reject challenge after window closes", async function () {
+      const { resultVerifier, user2, taskId } = await loadFixture(completedTaskFixture);
+
+      // Fast forward past challenge window (600s)
+      await ethers.provider.send("evm_increaseTime", [601]);
+      await ethers.provider.send("evm_mine", []);
+
+      await expect(
+        resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Too late", { value: MIN_CHALLENGE_STAKE })
+      ).to.be.revertedWithCustomError(resultVerifier, "ChallengeWindowClosed");
+    });
+
+    it("Should allow validators to vote", async function () {
+      const { resultVerifier, user2, validator1, validator2, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+
+      await expect(resultVerifier.connect(validator1).vote(1, true))
+        .to.emit(resultVerifier, "VoteCast")
+        .withArgs(1, validator1.address, true);
+
+      await expect(resultVerifier.connect(validator2).vote(1, false))
+        .to.emit(resultVerifier, "VoteCast")
+        .withArgs(1, validator2.address, false);
+
+      const challenge = await resultVerifier.getChallenge(1);
+      expect(challenge.votesFor).to.equal(1);
+      expect(challenge.votesAgainst).to.equal(1);
+    });
+
+    it("Should reject vote from non-validator", async function () {
+      const { resultVerifier, user1, user2, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+
+      await expect(
+        resultVerifier.connect(user1).vote(1, true)
+      ).to.be.revertedWithCustomError(resultVerifier, "NotValidator");
+    });
+
+    it("Should reject duplicate vote", async function () {
+      const { resultVerifier, user2, validator1, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+      await resultVerifier.connect(validator1).vote(1, true);
+
+      await expect(
+        resultVerifier.connect(validator1).vote(1, false)
+      ).to.be.revertedWithCustomError(resultVerifier, "AlreadyVoted");
+    });
+
+    it("Should resolve upheld challenge — slash miner, refund challenger", async function () {
+      const { resultVerifier, minerRegistry, user2, validator1, validator2, miner1, taskId } =
+        await loadFixture(completedTaskFixture);
+
+      // File challenge
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong output", { value: MIN_CHALLENGE_STAKE });
+
+      // Validators vote to uphold (2-0)
+      await resultVerifier.connect(validator1).vote(1, true);
+      await resultVerifier.connect(validator2).vote(1, true);
+
+      // Check miner reputation before
+      const [, , repBefore] = await minerRegistry.getMinerStats(miner1.address);
+      expect(repBefore).to.equal(10000);
+
+      // Resolve
+      const challengerBalBefore = await ethers.provider.getBalance(user2.address);
+
+      await expect(resultVerifier.resolveChallenge(1))
+        .to.emit(resultVerifier, "ChallengeResolved")
+        .withArgs(1, 1); // Upheld
+
+      // Miner reputation slashed by 10% (1000 bps)
+      const [completed, failed, repAfter] = await minerRegistry.getMinerStats(miner1.address);
+      expect(failed).to.equal(1);
+      expect(repAfter).to.equal(9000); // 10000 - 10%
+
+      // Challenger refunded
+      const challengerBalAfter = await ethers.provider.getBalance(user2.address);
+      expect(challengerBalAfter - challengerBalBefore).to.equal(MIN_CHALLENGE_STAKE);
+
+      // Challenge is upheld
+      const challenge = await resultVerifier.getChallenge(1);
+      expect(challenge.status).to.equal(1); // Upheld
+    });
+
+    it("Should resolve rejected challenge — challenger loses stake", async function () {
+      const { resultVerifier, minerRegistry, user2, validator1, validator2, miner1, taskId } =
+        await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+
+      // Validators vote to reject (0-2)
+      await resultVerifier.connect(validator1).vote(1, false);
+      await resultVerifier.connect(validator2).vote(1, false);
+
+      const challengerBalBefore = await ethers.provider.getBalance(user2.address);
+
+      await expect(resultVerifier.resolveChallenge(1))
+        .to.emit(resultVerifier, "ChallengeResolved")
+        .withArgs(1, 2); // Rejected
+
+      // Miner reputation unchanged
+      const [, , rep] = await minerRegistry.getMinerStats(miner1.address);
+      expect(rep).to.equal(10000);
+
+      // Challenger NOT refunded
+      const challengerBalAfter = await ethers.provider.getBalance(user2.address);
+      expect(challengerBalAfter).to.equal(challengerBalBefore);
+
+      // 50% of stake goes to protocol fees
+      const expectedProtocol = (MIN_CHALLENGE_STAKE * 5000n) / 10000n;
+      expect(await resultVerifier.protocolFees()).to.equal(expectedProtocol);
+    });
+
+    it("Should expire challenge after window with no resolution", async function () {
+      const { resultVerifier, user2, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+
+      // Can't expire before window
+      await expect(
+        resultVerifier.expireChallenge(1)
+      ).to.be.revertedWith("Challenge window not expired");
+
+      // Fast forward past window
+      await ethers.provider.send("evm_increaseTime", [601]);
+      await ethers.provider.send("evm_mine", []);
+
+      const balBefore = await ethers.provider.getBalance(user2.address);
+
+      await expect(resultVerifier.expireChallenge(1))
+        .to.emit(resultVerifier, "ChallengeExpired")
+        .withArgs(1);
+
+      // Challenger refunded on expiry
+      const balAfter = await ethers.provider.getBalance(user2.address);
+      expect(balAfter - balBefore).to.equal(MIN_CHALLENGE_STAKE);
+
+      const challenge = await resultVerifier.getChallenge(1);
+      expect(challenge.status).to.equal(3); // Expired
+    });
+
+    it("Should reject resolve from non-owner", async function () {
+      const { resultVerifier, user1, user2, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+
+      await expect(
+        resultVerifier.connect(user1).resolveChallenge(1)
+      ).to.be.revertedWithCustomError(resultVerifier, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should allow owner to claim protocol fees from rejected challenges", async function () {
+      const { resultVerifier, owner, user2, validator1, taskId } = await loadFixture(completedTaskFixture);
+
+      await resultVerifier.connect(user2).challengeResult(taskId, CHALLENGER_RESULT, "Wrong", { value: MIN_CHALLENGE_STAKE });
+      await resultVerifier.connect(validator1).vote(1, false);
+      await resultVerifier.resolveChallenge(1);
+
+      const expectedFees = (MIN_CHALLENGE_STAKE * 5000n) / 10000n;
+      const balBefore = await ethers.provider.getBalance(owner.address);
+      const tx = await resultVerifier.claimProtocolFees();
+      const receipt = await tx.wait();
+      const gasUsed = receipt!.gasUsed * receipt!.gasPrice;
+      const balAfter = await ethers.provider.getBalance(owner.address);
+
+      expect(balAfter - balBefore + gasUsed).to.equal(expectedFees);
+      expect(await resultVerifier.protocolFees()).to.equal(0);
+    });
+
+    it("Should allow admin to update challenge window and slash penalty", async function () {
+      const { resultVerifier } = await loadFixture(completedTaskFixture);
+
+      await expect(resultVerifier.setChallengeWindow(1200))
+        .to.emit(resultVerifier, "ChallengeWindowUpdated")
+        .withArgs(1200);
+      expect(await resultVerifier.challengeWindow()).to.equal(1200);
+
+      await expect(resultVerifier.setSlashPenalty(2000))
+        .to.emit(resultVerifier, "SlashPenaltyUpdated")
+        .withArgs(2000);
+      expect(await resultVerifier.slashPenaltyBps()).to.equal(2000);
+    });
+
+    it("Should allow add/remove validators", async function () {
+      const { resultVerifier, user1 } = await loadFixture(completedTaskFixture);
+
+      await expect(resultVerifier.addValidator(user1.address))
+        .to.emit(resultVerifier, "ValidatorAdded")
+        .withArgs(user1.address);
+      expect(await resultVerifier.validators(user1.address)).to.be.true;
+
+      await expect(resultVerifier.removeValidator(user1.address))
+        .to.emit(resultVerifier, "ValidatorRemoved")
+        .withArgs(user1.address);
+      expect(await resultVerifier.validators(user1.address)).to.be.false;
+    });
+
+    it("Should store completedAt timestamp on task", async function () {
+      const { taskRegistry, taskId } = await loadFixture(completedTaskFixture);
+
+      const task = await taskRegistry.getTask(taskId);
+      expect(task.completedAt).to.be.greaterThan(0);
+      expect(task.status).to.equal(2); // Completed
     });
   });
 });


### PR DESCRIPTION
## Summary
- **ResultVerifier** rewritten to fix compilation errors and match the challenge-response spec from #14
- **TaskRegistry** extended with `completedAt` timestamp and `getTask()` view function
- **MinerRegistry** extended with `slash()` function and `resultVerifier` role for reputation penalties
- Bumped Solidity compiler to 0.8.28 (fixes `^0.8.28` pragma compatibility)

### Verification Flow
1. Miner submits result + hash proof → task marked `Completed` with `completedAt` timestamp
2. 10-min challenge window — anyone can call `challengeResult()` with a stake and re-computed result hash
3. Validators vote (`vote()`) — uphold (miner wrong) or reject (miner right)
4. Owner resolves (`resolveChallenge()`):
   - **Upheld**: miner slashed 10% reputation, challenger stake refunded
   - **Rejected**: challenger loses stake (50% protocol, 50% retained)
5. Unresolved challenges can be expired (`expireChallenge()`) — challenger refunded

### Key Fixes
- Task ID type changed from `uint256` to `bytes32` (matches TaskRegistry)
- `task.completedAt` field added (was referencing non-existent field)
- `taskRegistry.getTask()` added (was missing)
- `minerRegistry.slash()` added with `onlyResultVerifier` access control

## Test plan
- [x] 41 tests passing (25 existing + 16 new ResultVerifier tests)
- [x] Challenge creation, stake validation, window enforcement
- [x] Validator voting, duplicate vote prevention
- [x] Upheld resolution with miner slash + challenger refund
- [x] Rejected resolution with stake forfeiture + protocol fees
- [x] Challenge expiry with refund
- [x] Admin functions (window, penalty, validators, fee claims)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)