### PR TITLE
fix: GovernorContract — snapshot voting, execution, admin transfer

### DIFF
--- a/contracts/governance/GovernorContract.sol
+++ b/contracts/governance/GovernorContract.sol
@@ -6,10 +6,11 @@ pragma solidity ^0.8.24;
  * @dev Simplified on-chain DAO voting contract for QFC Network.
  *      No OpenZeppelin dependency — standalone implementation.
  *
- * - Voting power = QFC balance at proposal snapshot block
- * - Quorum: 4% of total supply
+ * - Voting power = token.getPastVotes() at proposal snapshot block (ERC20Votes)
+ * - Quorum: 4% of total supply at snapshot
  * - Voting period: 3 days (testnet: 1 hour)
  * - Timelock: 2 days before execution (testnet: 10 min)
+ * - Execution deadline: 14 days after timelock (prevents stale execution)
  * - Proposal types: ParameterChange / ProtocolUpgrade / Treasury / General
  */
 
@@ -18,13 +19,18 @@ interface IERC20 {
     function totalSupply() external view returns (uint256);
 }
 
+interface IVotes {
+    function getPastVotes(address account, uint256 timepoint) external view returns (uint256);
+    function getPastTotalSupply(uint256 timepoint) external view returns (uint256);
+}
+
 contract GovernorContract {
     // -------------------------------------------------------
     // Types
     // -------------------------------------------------------
 
     enum ProposalType { ParameterChange, ProtocolUpgrade, Treasury, General }
-    enum ProposalState { Pending, Active, Defeated, Succeeded, Queued, Executed, Cancelled }
+    enum ProposalState { Pending, Active, Defeated, Succeeded, Queued, Executed, Cancelled, Expired }
 
     struct Proposal {
         uint256 id;
@@ -32,11 +38,14 @@ contract GovernorContract {
         string title;
         string description;
         ProposalType ptype;
+        address target;           // execution target contract
         bytes callData;
         uint256 snapshotBlock;
+        uint256 snapshotTotalSupply;  // total supply at snapshot for quorum calc
         uint256 voteStart;
         uint256 voteEnd;
         uint256 executableAfter;  // timelock: voteEnd + timelockDuration
+        uint256 executionDeadline; // must execute before this timestamp
         uint256 forVotes;
         uint256 againstVotes;
         uint256 abstainVotes;
@@ -55,11 +64,13 @@ contract GovernorContract {
     // -------------------------------------------------------
 
     IERC20 public immutable token;
+    IVotes public immutable votes;
     address public admin;
 
-    uint256 public votingPeriod;    // seconds
-    uint256 public timelockDuration; // seconds
-    uint256 public quorumBps;       // basis points (400 = 4%)
+    uint256 public votingPeriod;       // seconds
+    uint256 public timelockDuration;   // seconds
+    uint256 public executionWindow;    // seconds after timelock where execution is allowed
+    uint256 public quorumBps;          // basis points (400 = 4%)
 
     uint256 public proposalCount;
     mapping(uint256 => Proposal) public proposals;
@@ -74,6 +85,7 @@ contract GovernorContract {
         address indexed proposer,
         string title,
         ProposalType ptype,
+        address target,
         uint256 voteStart,
         uint256 voteEnd
     );
@@ -85,6 +97,7 @@ contract GovernorContract {
     );
     event ProposalExecuted(uint256 indexed proposalId);
     event ProposalCancelled(uint256 indexed proposalId);
+    event AdminTransferred(address indexed oldAdmin, address indexed newAdmin);
 
     // -------------------------------------------------------
     // Errors
@@ -99,13 +112,16 @@ contract GovernorContract {
     error AlreadyExecuted();
     error ProposalCancelledErr();
     error NotProposerOrAdmin();
+    error NotAdmin();
+    error ZeroAddress();
+    error ExecutionFailed();
 
     // -------------------------------------------------------
     // Constructor
     // -------------------------------------------------------
 
     /**
-     * @param _token QFC ERC-20 token address (voting power source)
+     * @param _token QFC ERC-20 token address (must implement ERC20Votes: getPastVotes, getPastTotalSupply)
      * @param _votingPeriod Duration of voting in seconds (mainnet: 259200 = 3 days, testnet: 3600 = 1 hour)
      * @param _timelockDuration Delay before execution in seconds (mainnet: 172800 = 2 days, testnet: 600 = 10 min)
      * @param _quorumBps Quorum in basis points (400 = 4%)
@@ -117,9 +133,11 @@ contract GovernorContract {
         uint256 _quorumBps
     ) {
         token = IERC20(_token);
+        votes = IVotes(_token);
         admin = msg.sender;
         votingPeriod = _votingPeriod;
         timelockDuration = _timelockDuration;
+        executionWindow = 14 days;  // proposals expire 14 days after timelock
         quorumBps = _quorumBps;
     }
 
@@ -132,13 +150,15 @@ contract GovernorContract {
      * @param title Short title for the proposal
      * @param description Detailed description
      * @param ptype Proposal type
-     * @param callData Encoded call data for execution (can be empty for General)
+     * @param target Target contract address for execution (address(0) for General/no-op)
+     * @param callData Encoded call data for execution (can be empty)
      * @return proposalId The ID of the created proposal
      */
     function propose(
         string calldata title,
         string calldata description,
         ProposalType ptype,
+        address target,
         bytes calldata callData
     ) external returns (uint256) {
         if (bytes(title).length == 0) revert EmptyTitle();
@@ -148,6 +168,7 @@ contract GovernorContract {
 
         uint256 voteStart = block.timestamp;
         uint256 voteEnd = voteStart + votingPeriod;
+        uint256 execAfter = voteEnd + timelockDuration;
 
         proposals[proposalId] = Proposal({
             id: proposalId,
@@ -155,11 +176,14 @@ contract GovernorContract {
             title: title,
             description: description,
             ptype: ptype,
+            target: target,
             callData: callData,
             snapshotBlock: block.number,
+            snapshotTotalSupply: token.totalSupply(),
             voteStart: voteStart,
             voteEnd: voteEnd,
-            executableAfter: voteEnd + timelockDuration,
+            executableAfter: execAfter,
+            executionDeadline: execAfter + executionWindow,
             forVotes: 0,
             againstVotes: 0,
             abstainVotes: 0,
@@ -167,12 +191,14 @@ contract GovernorContract {
             cancelled: false
         });
 
-        emit ProposalCreated(proposalId, msg.sender, title, ptype, voteStart, voteEnd);
+        emit ProposalCreated(proposalId, msg.sender, title, ptype, target, voteStart, voteEnd);
         return proposalId;
     }
 
     /**
      * @dev Cast a vote on a proposal.
+     *      Voting power is read from the token's getPastVotes() at the proposal's
+     *      snapshot block, preventing double-voting via token transfers.
      * @param proposalId The proposal to vote on
      * @param support 0=against, 1=for, 2=abstain
      */
@@ -184,26 +210,27 @@ contract GovernorContract {
         Receipt storage r = receipts[proposalId][msg.sender];
         if (r.hasVoted) revert AlreadyVoted();
 
-        uint256 votes = token.balanceOf(msg.sender);
-        if (votes == 0) revert NoVotingPower();
+        uint256 votePower = votes.getPastVotes(msg.sender, p.snapshotBlock);
+        if (votePower == 0) revert NoVotingPower();
 
         r.hasVoted = true;
         r.support = support;
-        r.votes = votes;
+        r.votes = votePower;
 
         if (support == 0) {
-            p.againstVotes += votes;
+            p.againstVotes += votePower;
         } else if (support == 1) {
-            p.forVotes += votes;
+            p.forVotes += votePower;
         } else {
-            p.abstainVotes += votes;
+            p.abstainVotes += votePower;
         }
 
-        emit VoteCast(proposalId, msg.sender, support, votes);
+        emit VoteCast(proposalId, msg.sender, support, votePower);
     }
 
     /**
-     * @dev Execute a succeeded proposal after timelock.
+     * @dev Execute a succeeded proposal after timelock but before deadline.
+     *      If the proposal has a target and callData, calls target with callData.
      * @param proposalId The proposal to execute
      */
     function execute(uint256 proposalId) external {
@@ -216,6 +243,13 @@ contract GovernorContract {
         if (s != ProposalState.Succeeded) revert NotSucceeded();
 
         p.executed = true;
+
+        // Execute callData on target if provided
+        if (p.target != address(0) && p.callData.length > 0) {
+            (bool ok, ) = p.target.call(p.callData);
+            if (!ok) revert ExecutionFailed();
+        }
+
         emit ProposalExecuted(proposalId);
     }
 
@@ -234,6 +268,22 @@ contract GovernorContract {
     }
 
     // -------------------------------------------------------
+    // Admin
+    // -------------------------------------------------------
+
+    /**
+     * @dev Transfer admin role to a new address.
+     * @param newAdmin The new admin address
+     */
+    function transferAdmin(address newAdmin) external {
+        if (msg.sender != admin && msg.sender != address(this)) revert NotAdmin();
+        if (newAdmin == address(0)) revert ZeroAddress();
+        address oldAdmin = admin;
+        admin = newAdmin;
+        emit AdminTransferred(oldAdmin, newAdmin);
+    }
+
+    // -------------------------------------------------------
     // View functions
     // -------------------------------------------------------
 
@@ -249,17 +299,21 @@ contract GovernorContract {
 
         if (block.timestamp < p.voteEnd) return ProposalState.Active;
 
-        // Voting ended — check quorum and result
+        // Voting ended — check quorum and result using snapshot total supply
         uint256 totalVotes = p.forVotes + p.againstVotes + p.abstainVotes;
-        uint256 quorumRequired = (token.totalSupply() * quorumBps) / 10000;
+        uint256 quorumRequired = (p.snapshotTotalSupply * quorumBps) / 10000;
 
         if (totalVotes < quorumRequired || p.forVotes <= p.againstVotes) {
             return ProposalState.Defeated;
         }
 
-        // Succeeded, check if in timelock or ready
+        // Succeeded — check timelock and deadline
         if (block.timestamp < p.executableAfter) {
             return ProposalState.Queued;
+        }
+
+        if (block.timestamp > p.executionDeadline) {
+            return ProposalState.Expired;
         }
 
         return ProposalState.Succeeded;
@@ -281,12 +335,12 @@ contract GovernorContract {
     }
 
     /**
-     * @dev Check if quorum is reached for a proposal.
+     * @dev Check if quorum is reached for a proposal (uses snapshot total supply).
      */
     function quorumReached(uint256 proposalId) external view returns (bool) {
         Proposal storage p = proposals[proposalId];
         uint256 totalVotes = p.forVotes + p.againstVotes + p.abstainVotes;
-        uint256 quorumRequired = (token.totalSupply() * quorumBps) / 10000;
+        uint256 quorumRequired = (p.snapshotTotalSupply * quorumBps) / 10000;
         return totalVotes >= quorumRequired;
     }
 }

--- a/contracts/governance/mocks/MockERC20Votes.sol
+++ b/contracts/governance/mocks/MockERC20Votes.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+
+/**
+ * @title MockERC20Votes
+ * @dev ERC20 token with Votes extension for governance testing.
+ *      Holders must delegate to themselves (or others) to activate voting power.
+ */
+contract MockERC20Votes is ERC20, ERC20Permit, ERC20Votes {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 initialSupply
+    ) ERC20(name_, symbol_) ERC20Permit(name_) {
+        _mint(msg.sender, initialSupply);
+    }
+
+    // Required overrides for ERC20Votes
+    function _update(address from, address to, uint256 value)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._update(from, to, value);
+    }
+
+    function nonces(address owner_)
+        public
+        view
+        override(ERC20Permit, Nonces)
+        returns (uint256)
+    {
+        return super.nonces(owner_);
+    }
+}

--- a/test/GovernorContract.test.ts
+++ b/test/GovernorContract.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture, time, mine } from "@nomicfoundation/hardhat-network-helpers";
 
 describe("GovernorContract", function () {
   const VOTING_PERIOD = 3600; // 1 hour (testnet)
@@ -11,16 +11,26 @@ describe("GovernorContract", function () {
   async function deployFixture() {
     const [admin, proposer, voter1, voter2, voter3] = await ethers.getSigners();
 
-    // Deploy a simple ERC-20 for voting power
-    const Token = await ethers.getContractFactory("QFCToken");
-    const token = await Token.deploy("QFC", "QFC", SUPPLY, SUPPLY);
+    // Deploy ERC20Votes token
+    const Token = await ethers.getContractFactory("MockERC20Votes");
+    const token = await Token.deploy("QFC", "QFC", SUPPLY);
     await token.waitForDeployment();
 
-    // Distribute tokens: proposer 10%, voter1 3%, voter2 2%, voter3 1%
+    // Distribute tokens
     await token.transfer(proposer.address, ethers.parseEther("100000"));
     await token.transfer(voter1.address, ethers.parseEther("30000"));
     await token.transfer(voter2.address, ethers.parseEther("20000"));
     await token.transfer(voter3.address, ethers.parseEther("10000"));
+
+    // Delegate to self to activate voting power (required by ERC20Votes)
+    await token.connect(admin).delegate(admin.address);
+    await token.connect(proposer).delegate(proposer.address);
+    await token.connect(voter1).delegate(voter1.address);
+    await token.connect(voter2).delegate(voter2.address);
+    await token.connect(voter3).delegate(voter3.address);
+
+    // Mine a block so getPastVotes works (needs at least 1 block after delegation)
+    await mine(1);
 
     const Governor = await ethers.getContractFactory("GovernorContract");
     const governor = await Governor.deploy(
@@ -40,7 +50,7 @@ describe("GovernorContract", function () {
 
       const tx = await governor
         .connect(proposer)
-        .propose("Upgrade Protocol", "Description here", 1, "0x");
+        .propose("Upgrade Protocol", "Description here", 1, ethers.ZeroAddress, "0x");
 
       const receipt = await tx.wait();
       expect(receipt).to.not.be.null;
@@ -50,8 +60,10 @@ describe("GovernorContract", function () {
       expect(proposal.proposer).to.equal(proposer.address);
       expect(proposal.title).to.equal("Upgrade Protocol");
       expect(proposal.ptype).to.equal(1); // ProtocolUpgrade
+      expect(proposal.target).to.equal(ethers.ZeroAddress);
       expect(proposal.executed).to.be.false;
       expect(proposal.cancelled).to.be.false;
+      expect(proposal.snapshotTotalSupply).to.equal(SUPPLY);
 
       const state = await governor.state(1);
       expect(state).to.equal(1); // Active
@@ -61,7 +73,7 @@ describe("GovernorContract", function () {
       const { governor, proposer } = await loadFixture(deployFixture);
 
       await expect(
-        governor.connect(proposer).propose("Test", "Desc", 0, "0x")
+        governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x")
       ).to.emit(governor, "ProposalCreated");
     });
 
@@ -69,24 +81,24 @@ describe("GovernorContract", function () {
       const { governor, proposer } = await loadFixture(deployFixture);
 
       await expect(
-        governor.connect(proposer).propose("", "Desc", 0, "0x")
+        governor.connect(proposer).propose("", "Desc", 0, ethers.ZeroAddress, "0x")
       ).to.be.revertedWithCustomError(governor, "EmptyTitle");
     });
 
     it("increments proposalCount", async function () {
       const { governor, proposer } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("First", "Desc", 0, "0x");
-      await governor.connect(proposer).propose("Second", "Desc", 3, "0x");
+      await governor.connect(proposer).propose("First", "Desc", 0, ethers.ZeroAddress, "0x");
+      await governor.connect(proposer).propose("Second", "Desc", 3, ethers.ZeroAddress, "0x");
       expect(await governor.proposalCount()).to.equal(2);
     });
   });
 
   describe("castVote()", function () {
-    it("records vote and updates totals", async function () {
+    it("records vote using snapshot voting power", async function () {
       const { governor, proposer, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(voter1).castVote(1, 1); // vote for
 
       const receipt = await governor.getReceipt(1, voter1.address);
@@ -101,7 +113,7 @@ describe("GovernorContract", function () {
     it("prevents double voting", async function () {
       const { governor, proposer, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(voter1).castVote(1, 1);
 
       await expect(
@@ -109,11 +121,32 @@ describe("GovernorContract", function () {
       ).to.be.revertedWithCustomError(governor, "AlreadyVoted");
     });
 
+    it("prevents double-voting via token transfer", async function () {
+      const { governor, token, proposer, voter1, voter2 } = await loadFixture(deployFixture);
+
+      // Create proposal — snapshot taken at this block
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
+
+      // voter1 votes
+      await governor.connect(voter1).castVote(1, 1);
+
+      // voter1 transfers all tokens to voter2 AFTER voting
+      await token.connect(voter1).transfer(voter2.address, ethers.parseEther("30000"));
+
+      // voter2 votes — but their voting power is from the snapshot block,
+      // before the transfer, so they only have their original 20000
+      await governor.connect(voter2).castVote(1, 1);
+
+      const proposal = await governor.getProposal(1);
+      // voter1 had 30000, voter2 had 20000 at snapshot — total 50000 (not 50000+30000)
+      expect(proposal.forVotes).to.equal(ethers.parseEther("50000"));
+    });
+
     it("reverts if no voting power", async function () {
       const { governor, proposer } = await loadFixture(deployFixture);
       const [, , , , , noTokens] = await ethers.getSigners();
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
 
       await expect(
         governor.connect(noTokens).castVote(1, 1)
@@ -123,7 +156,7 @@ describe("GovernorContract", function () {
     it("reverts if voting period ended", async function () {
       const { governor, proposer, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await time.increase(VOTING_PERIOD + 1);
 
       await expect(
@@ -134,7 +167,7 @@ describe("GovernorContract", function () {
     it("handles abstain votes", async function () {
       const { governor, proposer, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(voter1).castVote(1, 2); // abstain
 
       const proposal = await governor.getProposal(1);
@@ -144,12 +177,12 @@ describe("GovernorContract", function () {
     });
   });
 
-  describe("Quorum check on execution", function () {
+  describe("Quorum check", function () {
     it("proposal is defeated without quorum", async function () {
       const { governor, proposer, voter3 } = await loadFixture(deployFixture);
 
       // voter3 has 10000 tokens = 1% of supply, below 4% quorum
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(voter3).castVote(1, 1);
       await time.increase(VOTING_PERIOD + 1);
 
@@ -161,7 +194,7 @@ describe("GovernorContract", function () {
       const { governor, proposer, admin, voter1 } = await loadFixture(deployFixture);
 
       // admin(840k) + voter1(30k) = enough for quorum
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(admin).castVote(1, 1);
       await governor.connect(voter1).castVote(1, 1);
       await time.increase(VOTING_PERIOD + 1);
@@ -169,13 +202,29 @@ describe("GovernorContract", function () {
       const state = await governor.state(1);
       expect(state).to.equal(4); // Queued (succeeded, in timelock)
     });
+
+    it("uses snapshot total supply for quorum (not live)", async function () {
+      const { governor, token, proposer, admin, voter1 } = await loadFixture(deployFixture);
+
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
+
+      // Snapshot total supply is 1M. Quorum = 4% = 40k.
+      // snapshotTotalSupply is stored at proposal creation
+      const proposal = await governor.getProposal(1);
+      expect(proposal.snapshotTotalSupply).to.equal(SUPPLY);
+
+      await governor.connect(admin).castVote(1, 1);
+      await governor.connect(voter1).castVote(1, 1);
+
+      expect(await governor.quorumReached(1)).to.be.true;
+    });
   });
 
   describe("Timelock enforcement", function () {
     it("cannot execute during timelock period", async function () {
       const { governor, proposer, admin, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(admin).castVote(1, 1);
       await governor.connect(voter1).castVote(1, 1);
       await time.increase(VOTING_PERIOD + 1);
@@ -189,12 +238,11 @@ describe("GovernorContract", function () {
     it("can execute after timelock expires", async function () {
       const { governor, proposer, admin, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(admin).castVote(1, 1);
       await governor.connect(voter1).castVote(1, 1);
       await time.increase(VOTING_PERIOD + TIMELOCK + 1);
 
-      // State should be Succeeded (past timelock)
       const state = await governor.state(1);
       expect(state).to.equal(3); // Succeeded
 
@@ -210,11 +258,68 @@ describe("GovernorContract", function () {
     });
   });
 
+  describe("Execution deadline", function () {
+    it("proposal expires after execution deadline", async function () {
+      const { governor, proposer, admin, voter1 } = await loadFixture(deployFixture);
+
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
+      await governor.connect(admin).castVote(1, 1);
+      await governor.connect(voter1).castVote(1, 1);
+
+      // Fast forward past execution deadline (votingPeriod + timelock + 14 days + 1)
+      await time.increase(VOTING_PERIOD + TIMELOCK + 14 * 86400 + 1);
+
+      const state = await governor.state(1);
+      expect(state).to.equal(7); // Expired
+
+      await expect(
+        governor.execute(1)
+      ).to.be.revertedWithCustomError(governor, "NotSucceeded");
+    });
+  });
+
+  describe("External execution", function () {
+    it("executes callData on target contract", async function () {
+      const { governor, proposer, admin, voter1 } = await loadFixture(deployFixture);
+
+      // Use governor's own transferAdmin as a simple target to test execution
+      const governorAddr = await governor.getAddress();
+      const newAdmin = voter1.address;
+      const callData = governor.interface.encodeFunctionData("transferAdmin", [newAdmin]);
+
+      await governor.connect(proposer).propose("Transfer Admin", "Desc", 0, governorAddr, callData);
+      await governor.connect(admin).castVote(1, 1);
+      await governor.connect(voter1).castVote(1, 1);
+      await time.increase(VOTING_PERIOD + TIMELOCK + 1);
+
+      await governor.execute(1);
+
+      expect(await governor.admin()).to.equal(newAdmin);
+    });
+
+    it("reverts if target call fails", async function () {
+      const { governor, proposer, admin, voter1 } = await loadFixture(deployFixture);
+
+      // Call transferAdmin with zero address — should revert
+      const governorAddr = await governor.getAddress();
+      const callData = governor.interface.encodeFunctionData("transferAdmin", [ethers.ZeroAddress]);
+
+      await governor.connect(proposer).propose("Bad Transfer", "Desc", 0, governorAddr, callData);
+      await governor.connect(admin).castVote(1, 1);
+      await governor.connect(voter1).castVote(1, 1);
+      await time.increase(VOTING_PERIOD + TIMELOCK + 1);
+
+      await expect(
+        governor.execute(1)
+      ).to.be.revertedWithCustomError(governor, "ExecutionFailed");
+    });
+  });
+
   describe("cancel()", function () {
     it("proposer can cancel", async function () {
       const { governor, proposer } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(proposer).cancel(1);
 
       const state = await governor.state(1);
@@ -224,7 +329,7 @@ describe("GovernorContract", function () {
     it("admin can cancel", async function () {
       const { governor, proposer, admin } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
       await governor.connect(admin).cancel(1);
 
       const state = await governor.state(1);
@@ -234,11 +339,39 @@ describe("GovernorContract", function () {
     it("others cannot cancel", async function () {
       const { governor, proposer, voter1 } = await loadFixture(deployFixture);
 
-      await governor.connect(proposer).propose("Test", "Desc", 0, "0x");
+      await governor.connect(proposer).propose("Test", "Desc", 0, ethers.ZeroAddress, "0x");
 
       await expect(
         governor.connect(voter1).cancel(1)
       ).to.be.revertedWithCustomError(governor, "NotProposerOrAdmin");
+    });
+  });
+
+  describe("transferAdmin()", function () {
+    it("admin can transfer admin role", async function () {
+      const { governor, admin, voter1 } = await loadFixture(deployFixture);
+
+      await expect(governor.connect(admin).transferAdmin(voter1.address))
+        .to.emit(governor, "AdminTransferred")
+        .withArgs(admin.address, voter1.address);
+
+      expect(await governor.admin()).to.equal(voter1.address);
+    });
+
+    it("non-admin cannot transfer", async function () {
+      const { governor, voter1 } = await loadFixture(deployFixture);
+
+      await expect(
+        governor.connect(voter1).transferAdmin(voter1.address)
+      ).to.be.revertedWithCustomError(governor, "NotAdmin");
+    });
+
+    it("cannot transfer to zero address", async function () {
+      const { governor, admin } = await loadFixture(deployFixture);
+
+      await expect(
+        governor.connect(admin).transferAdmin(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(governor, "ZeroAddress");
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes critical issues in GovernorContract.sol (merged in #48):

- **Snapshot-based voting**: Use ERC20Votes `getPastVotes()` at proposal's `snapshotBlock` instead of live `balanceOf()` — prevents double-voting via token transfers
- **Snapshot quorum**: Store `totalSupply` at proposal creation for quorum calculation instead of using live supply
- **External execution**: Proposals can target any contract address (not just `address(this)`)
- **Execution deadline**: Proposals expire 14 days after timelock (prevents stale execution)
- **Admin transfer**: `transferAdmin()` with event, zero-address check, and self-execution support
- **Expired state**: New `ProposalState.Expired` for proposals past their execution deadline
- **MockERC20Votes**: Test token with ERC20Votes extension for governance testing

## Test plan
- [x] 24 governor tests pass (up from 14)
- [x] Double-vote prevention test: voter transfers tokens after voting, recipient's voting power is from snapshot only
- [x] Execution deadline: proposal becomes Expired after 14 days
- [x] External execution: callData executed on target contract
- [x] Admin transfer: admin can transfer, non-admin rejected, zero-address rejected
- [x] Full suite: 382 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)