### PR TITLE
chore(gitignore): ignore witness artifacts for all circuits, not just withdraw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ build/circuits/*.r1cs
 build/circuits/*.sym
 build/circuits/*_0000.zkey
 build/circuits/*_0001.zkey
-build/circuits/withdraw_js/generate_witness.js
-build/circuits/withdraw_js/witness_calculator.js
+build/circuits/*_js/generate_witness.js
+build/circuits/*_js/witness_calculator.js
 
 # Test
 .nyc_output/


### PR DESCRIPTION
## 问题

`build/circuits/withdrawCompliant_js/` 下的 `generate_witness.js` 和 `witness_calculator.js` 一直以未追踪状态挂在工作区里。

这两个是 snarkjs 生成的胶水文件。`.gitignore` 里**本来就有**对应规则,但只写死了旧的 `withdraw` 电路:

```
build/circuits/withdraw_js/generate_witness.js
build/circuits/withdraw_js/witness_calculator.js
```

后来加 `withdrawCompliant` 电路时没同步更新,所以漏了。

## 改动

把这两行改成 `*_js` glob,顺带覆盖以后新增的任何电路:

```
build/circuits/*_js/generate_witness.js
build/circuits/*_js/witness_calculator.js
```

这个规则块里本来就在用 glob(`*.ptau` / `*.r1cs` / `*.sym`),风格一致。

## 安全性

glob 只匹配那两个 snarkjs 胶水文件。**该提交的电路产物完全不受影响** —— `build/circuits/` 下被追踪的 6 个文件(`.wasm`、`_final.zkey`、`verification_key.json`)全部验证过:

```
$ git ls-files build/ | while read f; do git check-ignore -q "$f" && echo "误伤: $f"; done
(无输出)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)