### PR TITLE
fix(relayer): repair Dockerfile.relayer tsc build (broken since March)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
         platform: [linux/amd64, linux/arm64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/login-action@v3
         with:

--- a/Dockerfile.relayer
+++ b/Dockerfile.relayer
@@ -4,7 +4,7 @@ COPY package*.json ./
 RUN npm ci --production=false
 COPY relayer/ relayer/
 COPY tsconfig.json ./
-RUN npx tsc --outDir dist relayer/index.ts --esModuleInterop --resolveJsonModule --skipLibCheck
+RUN npx tsc --outDir dist --rootDir . --target ES2020 --module commonjs relayer/index.ts --esModuleInterop --resolveJsonModule --skipLibCheck
 
 FROM node:22-alpine
 WORKDIR /app


### PR DESCRIPTION
## 背景

[Docker workflow](https://github.com/qfc-network/qfc-contracts/actions/runs/29679232309) 挂了。查了历史:**这个 workflow 从 2026 年 3 月加进来起,每一次 push 到 main 都失败** —— 只是从来没有东西 gate 在它上面,所以没人管。触发这次的 push(我合的 .gitignore PR #58)只是重新跑了它一遍,不是根因。

## 两个独立缺陷

根子都在 `Dockerfile.relayer` 用**显式文件名**调 `tsc`,导致它**完全忽略 tsconfig.json**(即使 Dockerfile 第 6 行还 COPY 了 tsconfig 进去):

**1. 编译错误 TS2802** — `relayer/index.ts:89` spread 了一个 Map 迭代器(`[...jobs.values()]`)。没有 tsconfig,target 默认 ES3,无法迭代 Map。
- 修:加 `--target ES2020`(和 tsconfig 一致)
- 连带 TS5070:target 升高后默认 module 变 ES2020 → moduleResolution 变 classic → `--resolveJsonModule` 报错,所以还需 `--module commonjs`

**2. 产物路径不匹配(运行时会崩)** — 单文件编译时 tsc 把 rootDir 设成 `relayer/`,于是产物是 `dist/index.js`,而 `CMD` 跑的是 `dist/relayer/index.js`。就算编译修好,镜像启动也会 `Cannot find module`。
- 修:加 `--rootDir .`,保留 `relayer/` 前缀

## 改动

```diff
-RUN npx tsc --outDir dist relayer/index.ts --esModuleInterop --resolveJsonModule --skipLibCheck
+RUN npx tsc --outDir dist --rootDir . --target ES2020 --module commonjs relayer/index.ts --esModuleInterop --resolveJsonModule --skipLibCheck
```

顺带把 `docker.yml` 的 `actions/checkout` v4→v5,清 Node 20 弃用告警。

## 验证

本机跑了完整 `docker build`(不是只 tsc):
- ✅ 镜像 build 成功
- ✅ `dist/relayer/index.js` 在镜像内存在,`node --check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)