### PR TITLE
fix(ci): build multi-arch relayer image in one job, drop manual manifest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,57 +17,28 @@ jobs:
       contents: read
       packages: write
 
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
-
     steps:
       - uses: actions/checkout@v5
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.relayer
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  manifest:
-    name: Create Manifest
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push'
-    permissions:
-      packages: write
-
-    steps:
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create multi-arch manifest
-        run: |
-          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-
-          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## 背景

上个 PR 修好 tsc build 之后,Docker workflow **第一次跑到了 manifest 阶段**——然后在那里也挂了:

```
docker manifest create ... : ghcr.io/qfc-network/qfc-relayer:main-amd64 is a manifest list
```

`build-push-action@v6` 默认附加 SLSA provenance,所以每个单架构 tag(`main-amd64` / `main-arm64`)本身就是一个 manifest list(镜像 + 证明 index)。老式的 `docker manifest create` 拒绝把一个 manifest list 再套进另一个,所以这个阶段**从设计上就不可能跑通**。

## 改动

没有用 `provenance: false` 去打补丁,而是**把两个 matrix job + 手动 manifest job 合成一个** `build-push-action` 调用,`platforms: linux/amd64,linux/arm64`。buildx 原生就会产出正确的多架构 OCI index,所以整段脆弱的「单架构 tag + `docker manifest create`」全部删掉。加了 `setup-qemu-action` 保证合并 build 里的 arm64 模拟。

产出的 tag 不变:`:<ref_name>` 和 `:latest`。

## 验证说明

⚠️ 和 build 修复不同,这个**没法本机复现**——manifest list 的行为只在真实的 GHCR 多架构推送流程里出现。唯一验证方式是合进 main 后看 Docker run。合并后我会盯着确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)